### PR TITLE
Importable Library for HEP parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*.class
+*.iml
+target/

--- a/src/main/java/org/homer/hep/HEPStructure.java
+++ b/src/main/java/org/homer/hep/HEPStructure.java
@@ -44,5 +44,30 @@ public class HEPStructure {
 	public boolean authorized = false;	
 	public ByteBuffer payloadByteMessage = null;	
 	public long recievedTimestamp;
-	public String node;	
+	public String node;
+
+	@Override
+    public String toString(){
+	    StringBuilder sb = new StringBuilder();
+	    sb.append("HEPStructure[")
+                .append("ipFamily: " + ipFamily)
+                .append(", protcolId: " + protocolId)
+                .append(", sourcePort: " + sourcePort)
+                .append(", destinationPort: " + destinationPort)
+                .append(", timeSeconds: " + timeSeconds)
+                .append(", timeUseconds: " + timeUseconds)
+                .append(", protocolType: " + protocolType)
+                .append(", captureId: " + captureId)
+                .append(", hepCorrelationID: " + hepCorrelationID)
+                .append(", captureAuthUser: " + captureAuthUser)
+                .append(", sourceIPAddress: " + sourceIPAddress)
+                .append(", destinationIPAddress: " + destinationIPAddress)
+                .append(", uuid: " + uuid)
+                .append(", authorized: " + authorized)
+                .append(", payloadByteMessage: " + payloadByteMessage)
+                .append(", recievedTimestamp: " + recievedTimestamp)
+                .append(", node: " + node)
+                .append("]");
+	    return sb.toString();
+    }
 }

--- a/src/main/java/org/homer/hep/ParserHEPv3.java
+++ b/src/main/java/org/homer/hep/ParserHEPv3.java
@@ -56,7 +56,7 @@ public class ParserHEPv3 {
 			int i = 6;			
 
 
-			/* recieved time */
+			/* received time */
 			hepStruct.recievedTimestamp = hepStruct.timeSeconds * 1000000 + hepStruct.timeUseconds;			            
 
 			while (i < totalLength) {

--- a/src/main/java/org/homer/hep/ParserHEPv3.java
+++ b/src/main/java/org/homer/hep/ParserHEPv3.java
@@ -158,14 +158,10 @@ public class ParserHEPv3 {
 				i += chunk_length;
 								
 			}
-			
-			
-			hepStruct = null;
-
-
 		} catch (Exception e) {
 			e.printStackTrace();
 			System.out.println("Unable RUN WORKER");
+			throw e;
 		}
 		return hepStruct;
     }	

--- a/src/main/java/org/homer/hep/ParserHEPv3.java
+++ b/src/main/java/org/homer/hep/ParserHEPv3.java
@@ -36,6 +36,15 @@ public class ParserHEPv3 {
   	public static final int WIDTH = 4;
 	public static final int WIDTH_V6 = 128; // in bits
 
+    /**
+     * Method to parse out HEPStructure from input byte buffer.
+     *
+     * @param msg             payload bytes
+     * @param totalLength     length of payload
+     * @param remoteIPAddress IP address of remote host
+     * @return HEPStructure instance
+     * @throws Exception
+     */
 	public HEPStructure parse(ByteBuffer msg, int totalLength, String remoteIPAddress) throws Exception {
 
         HEPStructure hepStruct = new HEPStructure();

--- a/src/main/java/org/homer/hep/ParserHEPv3.java
+++ b/src/main/java/org/homer/hep/ParserHEPv3.java
@@ -36,8 +36,9 @@ public class ParserHEPv3 {
   	public static final int WIDTH = 4;
 	public static final int WIDTH_V6 = 128; // in bits
 
-	public ParserHEPv3(ByteBuffer msg, int totalLength, String remoteIPAddress) throws Exception {
+	public HEPStructure parse(ByteBuffer msg, int totalLength, String remoteIPAddress) throws Exception {
 
+        HEPStructure hepStruct = new HEPStructure();
 		try {
 
 			int chunk_id = 0;
@@ -45,7 +46,7 @@ public class ParserHEPv3 {
 			int chunk_length = 0;
 			int i = 6;			
 
-			HEPStructure hepStruct = new HEPStructure();
+
 			/* recieved time */
 			hepStruct.recievedTimestamp = hepStruct.timeSeconds * 1000000 + hepStruct.timeUseconds;			            
 
@@ -56,12 +57,12 @@ public class ParserHEPv3 {
 				
 				if(chunk_length > totalLength) {
 					System.out.println("Corrupted HEP: CHUNK LENGHT couldnt be bigger as CHUNK_LENGHT");
-					return;
+                    throw new IOException("Invalid HEP payload.");
 				}
 				
 				if(chunk_length == 0) {
 					System.out.println("Corrupted HEP: LENGTH couldn't be 0!");
-					return;
+                    throw new IOException("Invalid HEP payload.");
 				}
 
 				/* working with based HEP */
@@ -157,6 +158,7 @@ public class ParserHEPv3 {
 			e.printStackTrace();
 			System.out.println("Unable RUN WORKER");
 		}
+		return hepStruct;
     }	
 	
     public static byte[] extractBytes(byte[] input, int position, int len) throws UnsupportedEncodingException, IOException, DataFormatException


### PR DESCRIPTION
Hi,

In writing an application to parse an incoming HEP stream, we discovered that changes were needed to the java reference implementation to make it usable as a library. Basic idea was to be able to import the library as a jar, instantiate the parser class,  and be able to parse out the HEPStructure. Wanted to see if there is any interest in merging the changes in. 

Here is an example of using the library in an application after the changes:

```

//...
//...
import org.homer.hep.ParserHEPv3;
import org.homer.hep.HEPStructure;
//...
//...

void consume(Socket socket) {
    // hep input stream      
    InputStream in = socket.getInputStream();
    
    // get header bytes
    byte[] header = new byte[4];
    byte[] expectedHeader = {0x48, 0x45, 0x50, 0x33};
    in.read(header);

    // check if header spells "HEP3"
    if (Arrays.equals(header, expectedHeader)){
        
        // get the total length bytes
        byte[] lenBytes = new byte[2]; 
        in.read(lenBytes);
        int len = ((lenBytes[0]<<8)+ lenBytes[1]);
        // get payload bytes
        byte[] bytes = new byte[len];
        in.read(bytes);

        // parse out HEP structure
        ParserHEPv3 parser = new ParserHEPv3();
        HEPStructure hepStructure = parser.parse(ByteBuffer.wrap(bytes), len, socket.getInetAddress().toString());
        // this prints out the HEP structure string representation
        System.out.println("HEP Structure: " + hepStructure);

        // grab payload from HEP structure
        String payload = new String(hepStructure.payloadByteMessage.array());
        //...
        //... do stuff with payload
        //...
    }
}

```

